### PR TITLE
Add DaisyUI exclusion note to moduledoc

### DIFF
--- a/lib/toast.ex
+++ b/lib/toast.ex
@@ -43,6 +43,11 @@ defmodule Toast do
       /* For assets in nested folders (e.g., assets/css/app.css): */
       @import "../../deps/toast/assets/css/toast.css";
 
+      /* If you are using DaisyUI, exclude their toast component to avoid conflicts: */
+      @plugin "../vendor/daisyui" {
+        exclude: toast;
+      }
+
   3. Add the toast container to your root layout:
 
       <Toast.toast_group flash={@flash} />


### PR DESCRIPTION
Fixes #2 - Document how to exclude DaisyUI's toast component to avoid CSS class conflicts.

Added documentation to the Toast module's @moduledoc showing users how to exclude DaisyUI's toast component when using both libraries together. This prevents CSS class conflicts without requiring any breaking changes to the existing API.